### PR TITLE
Tools: harden GitHub/Railway CLI wrappers (no shell, masked output, timeouts)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
 [pytest]
 testpaths = tests
-norecursedirs = scratch .venv node_modules dist build .git
+norecursedirs = scratch .venv venv node_modules
 addopts = -q
-filterwarnings =
-    ignore::DeprecationWarning:fastapi.*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = tests
-norecursedirs = scratch .git .venv node_modules
+norecursedirs = scratch .venv node_modules dist build .git
+addopts = -q
+filterwarnings =
+    ignore::DeprecationWarning:fastapi.*

--- a/tests/test_tools_wrappers.py
+++ b/tests/test_tools_wrappers.py
@@ -1,0 +1,30 @@
+import subprocess
+from tools.github_tools import gh_pr_create
+from tools.railway_tools import _run as rw_run
+
+
+class FakeRun:
+    def __init__(self, rc=0, out="OK", err=""):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = err
+
+
+def test_gh_pr_create_no_shell(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, timeout):
+        # ensure cmd is a list and uses gh pr create
+        assert isinstance(cmd, list)
+        assert "pr" in cmd and "create" in cmd
+        return FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc, out, err = gh_pr_create("main", "feat/x", "t", "b")
+    assert rc == 0
+
+
+def test_railway_run_masks_token(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, timeout):
+        return FakeRun(out=(env.get('RAILWAY_TOKEN','') or 'no'))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc, out, err = rw_run(["railway", "projects", "list"], timeout=5)
+    # out should be string, token masked if present (we didn't set token)
+    assert isinstance(out, str)

--- a/tools/github_tools.py
+++ b/tools/github_tools.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+from typing import Optional, Dict, Any, List
+from vme_lib.supabase_client import settings_get
+
+
+def _gh_env():
+    env = os.environ.copy()
+    tok = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN") or (settings_get("GITHUB_PAT") or "")
+    if tok:
+        env["GH_TOKEN"] = tok
+    return env
+
+
+def _run(cmd: List[str], timeout: int = 60):
+    # NEVER use shell=True; capture output and mask tokens
+    p = subprocess.run(cmd, capture_output=True, text=True, env=_gh_env(), timeout=timeout)
+    out = (p.stdout or "").strip()
+    err = (p.stderr or "").strip()
+    tok = _gh_env().get("GH_TOKEN", "")
+    if tok:
+        out = out.replace(tok, "***")
+        err = err.replace(tok, "***")
+    return p.returncode, out, err
+
+
+def gh_pr_create(base: str, head: str, title: Optional[str] = None, body: Optional[str] = None):
+    # validate branch names minimally
+    for s in (base, head):
+        if not s or any(c.isspace() for c in s):
+            return 400, "", "invalid branch name"
+    cmd = ["gh", "pr", "create", "--base", base, "--head", head, "--fill"]
+    if title:
+        cmd += ["--title", title]
+    if body:
+        cmd += ["--body", body]
+    return _run(cmd)

--- a/tools/railway_tools.py
+++ b/tools/railway_tools.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from typing import Dict, Any, List
+from vme_lib.supabase_client import settings_get
+
+
+def _rw_env():
+    env = os.environ.copy()
+    tok = os.getenv("RAILWAY_TOKEN") or (settings_get("RAILWAY_TOKEN") or "")
+    if tok:
+        env["RAILWAY_TOKEN"] = tok
+    return env
+
+
+def _run(cmd: List[str], timeout: int = 60):
+    p = subprocess.run(cmd, capture_output=True, text=True, env=_rw_env(), timeout=timeout)
+    out = (p.stdout or "").strip()
+    err = (p.stderr or "").strip()
+    tok = _rw_env().get("RAILWAY_TOKEN", "")
+    if tok:
+        out = out.replace(tok, "***")
+        err = err.replace(tok, "***")
+    return p.returncode, out, err
+
+
+def railway_deploy(project_id: str | None = None, service_name: str | None = None):
+    cmd = ["railway", "up"]
+    if project_id:
+        cmd += ["--project", project_id]
+    if service_name:
+        cmd += ["--service", service_name]
+    return _run(cmd, timeout=600)
+
+
+def list_projects_cli() -> Dict[str, Any]:
+    return _run(["railway", "projects", "list"]) if True else (1, "", "disabled")


### PR DESCRIPTION
Summary

- github_tools.py / railway_tools.py use subprocess.run with list args (no shell).
- Tokens injected via env or settings; output scrubbed; timeouts; minimal validation.

Why

Prevents injection and token leaks; safer time-bounded calls.

Changes

- github_tools.py, railway_tools.py; tests: test_tools_wrappers.py (monkeypatched).

Verification

- pytest -q green locally; CI expected green.

Risk/rollback

Low; wrappers isolated; can be disabled.

/cc @JFraser74