### PR TITLE
feat(status): read-only Goals UI (/status/goals)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example .env for V-Me2 (do NOT commit secrets)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=service-role-key-here
+SUPABASE_ANON_KEY=anon-key-here
+DATABASE_URL=postgres://user:pass@host:5432/postgres
+APP_ENCRYPTION_KEY=<FERNET_KEY_HERE>
+SETTINGS_ADMIN_TOKEN=<admin-token>
+CI_SETTINGS_ADMIN_TOKEN=<ci-token>
+GITHUB_PAT=<github_pat>
+RAILWAY_TOKEN=<railway_token>
+# BRIDGE_MAX_CALLS is optional
+BRIDGE_MAX_CALLS=20

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,31 @@
+## V-Me2 Operations and Security Notes
+
+This document describes the runtime requirements for admin tokens, Supabase, and the Bridge peer registry.
+
+1. Admin tokens
+  - `SETTINGS_ADMIN_TOKEN` protects the `/api/settings` and `/api/bridge/*` endpoints.
+  - `CI_SETTINGS_ADMIN_TOKEN` is an optional token used for CI / automation.
+  - Tokens may be provided via environment variables or stored in `va_settings` (encrypted when `APP_ENCRYPTION_KEY` is set).
+
+2. Supabase
+  - Provide `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for full server-side operation.
+  - Apply schema in `db/schema.sql` via Supabase SQL editor or using psql with `DATABASE_URL`.
+
+3. Encryption
+  - `APP_ENCRYPTION_KEY` (Fernet) enables encryption of secret settings stored in Supabase. Generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`.
+
+4. Bridge peer registry
+  - Peers are writable via `/api/bridge/peers` and require admin tokens.
+  - Local file fallback (`.vme2_settings.json`) stores non-secret info only (names + urls). Tokens are never written to disk unless you explicitly add local encryption.
+  - Rate limiting: per-admin token in-memory counter to prevent bursts. Configure with `BRIDGE_MAX_CALLS`.
+
+5. Smoke and CI
+  - Use `SMOKE` scripts with `SETTINGS_ADMIN_TOKEN` or `CI_SETTINGS_ADMIN_TOKEN` set in the environment.
+
+6. Rotating tokens
+  - Use the `/api/settings/rotate_admin` endpoint (protected by admin token) to generate a new `SETTINGS_ADMIN_TOKEN` and persist it. Update environment/CI secrets as needed.
+
+7. Debugging
+  - `/api/_debug/supacall` and `/api/_debug/railway_inspect` exist to help diagnose deployment issues (they are intentionally minimal and do not return secret values).
+
+Keep secrets out of git and use your platform secret manager for production deployments.

--- a/main.py
+++ b/main.py
@@ -159,6 +159,15 @@ except Exception:
   pass
 
 
+# Ensure status router (read-only goals UI) is mounted (safe include)
+try:
+  from routes.status import router as status_router
+  if status_router:
+    app.include_router(status_router)
+except Exception:
+  pass
+
+
 # Simple file-backed settings API used by the UI. This keeps settings local to the
 # repository (no external dependency) and allows toggling features such as
 # AGENT_USE_LANGGRAPH from the web UI. Settings are persisted to

--- a/main.py
+++ b/main.py
@@ -150,14 +150,12 @@ try:
 except Exception:
   pass
 
-# Ensure bridge router is mounted (some branches may omit it)
+# Ensure bridge router is mounted (safe include)
 try:
   from routes.bridge import router as bridge_router
   if bridge_router:
-    # router defines full paths (e.g. /api/bridge/...), include as-is to avoid double-prefix
     app.include_router(bridge_router)
 except Exception:
-  # Do not fail startup if bridge router is not present on the branch
   pass
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,6 +17,14 @@ python_functions = test_*
 norecursedirs = scratch scripts docs .git .venv node_modules
 addopts = -q
 
+markers = integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+norecursedirs = scratch scripts docs .git .venv node_modules
+addopts = -q
+
 markers =
     integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,14 @@ python_functions = test_*
 norecursedirs = scratch scripts docs .git .venv node_modules
 addopts = -q
 
+markers = integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+norecursedirs = scratch scripts docs .git .venv node_modules
+addopts = -q
+
 markers =
     integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,16 @@
 [pytest]
 testpaths = tests
+<<<<<<< HEAD
 norecursedirs = scratch .git .venv node_modules
+=======
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+norecursedirs = scratch scripts docs .git .venv node_modules
+addopts = -q
+
+markers =
+    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
+markers =
+    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)
+>>>>>>> 84a60ea (ci(test): ignore scratch from pytest collection (fix SyntaxError in railway_test.py))

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,15 @@ addopts = -q
 
 markers =
     integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+norecursedirs = scratch scripts docs .git .venv node_modules
+addopts = -q
+
+markers =
+    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
 markers =
     integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)
 >>>>>>> 84a60ea (ci(test): ignore scratch from pytest collection (fix SyntaxError in railway_test.py))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
+addopts = -q
 testpaths = tests
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 norecursedirs = scratch .git .venv node_modules
@@ -43,3 +45,8 @@ markers =
 =======
 norecursedirs = scratch .git .venv node_modules
 >>>>>>> b8d8d8b (tests(ci): ignore scratch dir from pytest collection)
+=======
+norecursedirs = scratch .git .venv venv node_modules
+filterwarnings =
+    ignore::DeprecationWarning
+>>>>>>> a256a9a (test(ci): canonical pytest.ini for CI)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 testpaths = tests
 <<<<<<< HEAD
+<<<<<<< HEAD
 norecursedirs = scratch .git .venv node_modules
 =======
 python_files = test_*.py
@@ -39,3 +40,6 @@ markers =
 markers =
     integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)
 >>>>>>> 84a60ea (ci(test): ignore scratch from pytest collection (fix SyntaxError in railway_test.py))
+=======
+norecursedirs = scratch .git .venv node_modules
+>>>>>>> b8d8d8b (tests(ci): ignore scratch dir from pytest collection)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,52 +1,6 @@
 [pytest]
 addopts = -q
 testpaths = tests
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-norecursedirs = scratch .git .venv node_modules
-=======
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-norecursedirs = scratch scripts docs .git .venv node_modules
-addopts = -q
-
-markers = integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
-testpaths = tests
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-norecursedirs = scratch scripts docs .git .venv node_modules
-addopts = -q
-
-markers = integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
-testpaths = tests
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-norecursedirs = scratch scripts docs .git .venv node_modules
-addopts = -q
-
-markers =
-    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
-testpaths = tests
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-norecursedirs = scratch scripts docs .git .venv node_modules
-addopts = -q
-
-markers =
-    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)[pytest]
-markers =
-    integration: mark a test as requiring LangGraph/OpenAI (run only when AGENT_USE_LANGGRAPH=1)
->>>>>>> 84a60ea (ci(test): ignore scratch from pytest collection (fix SyntaxError in railway_test.py))
-=======
-norecursedirs = scratch .git .venv node_modules
->>>>>>> b8d8d8b (tests(ci): ignore scratch dir from pytest collection)
-=======
 norecursedirs = scratch .git .venv venv node_modules
 filterwarnings =
     ignore::DeprecationWarning
->>>>>>> a256a9a (test(ci): canonical pytest.ini for CI)

--- a/routes/status.py
+++ b/routes/status.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+from pathlib import Path
+
+router = APIRouter(prefix="/status", tags=["status"])
+
+
+@router.get("/goals", response_class=HTMLResponse)
+def goals():
+    p = Path("static/goals.html")
+    if not p.exists():
+        return HTMLResponse("<h1>Goals</h1><p>No table available yet.</p>", status_code=200)
+    return HTMLResponse(p.read_text(encoding="utf-8"))

--- a/scripts/import_va_min.py
+++ b/scripts/import_va_min.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+scripts/import_va_min.py
+
+Simple, idempotent importer from a legacy Postgres (VA-min) into V-Me2 (Supabase).
+
+Usage examples:
+
+  # dry-run first, reading DSN from env
+  VA_MIN_DSN="postgres://..." python scripts/import_va_min.py --source-table messages --target-table va_messages --key-columns message_id --limit 1000 --dry-run
+
+  # store DSN encrypted in va_settings (requires Supabase configured and APP_ENCRYPTION_KEY set locally)
+  VA_MIN_DSN="postgres://..." python scripts/import_va_min.py --store-config
+
+Notes:
+ - Requires a Postgres client library: `pip install psycopg[binary]` or `pip install psycopg2-binary`.
+ - Requires Supabase server credentials available to this app (SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_KEY).
+ - The script prefers using the DSN from the environment variable VA_MIN_DSN, or from the repo settings (settings_get('VA_MIN_DSN')).
+ - The script uses the repo's Supabase client to upsert rows into the target table. If the underlying supabase client lacks upsert, it falls back to delete+insert per-row.
+"""
+import argparse
+import os
+import sys
+import json
+from typing import List, Dict, Any
+
+try:
+    import psycopg
+except Exception:
+    try:
+        import psycopg2 as psycopg
+    except Exception:
+        psycopg = None
+
+from vme_lib import supabase_client as _sbmod
+from vme_lib.supabase_client import settings_get, settings_put
+
+
+def get_source_dsn(provided: str | None) -> str | None:
+    if provided:
+        return provided
+    env = os.getenv('VA_MIN_DSN')
+    if env:
+        return env
+    # try settings (encrypted)
+    try:
+        v = settings_get('VA_MIN_DSN', default=None, decrypt=True)
+        if v:
+            return v
+    except Exception:
+        pass
+    return None
+
+
+def connect_source(dsn: str):
+    if psycopg is None:
+        raise RuntimeError('psycopg not installed. pip install psycopg[binary] or psycopg2-binary')
+    # support both psycopg>=3 and psycopg2
+    try:
+        # psycopg3 style
+        conn = psycopg.connect(dsn)
+        return conn
+    except Exception:
+        try:
+            conn = psycopg.connect(dsn)
+            return conn
+        except Exception as e:
+            raise
+
+
+def fetch_batch(conn, table: str, limit: int, offset: int):
+    cur = conn.cursor()
+    sql = f"SELECT * FROM {table} ORDER BY 1 LIMIT %s OFFSET %s"
+    cur.execute(sql, (limit, offset))
+    cols = [d[0] for d in cur.description]
+    rows = cur.fetchall()
+    results = [dict(zip(cols, r)) for r in rows]
+    cur.close()
+    return results
+
+
+def upsert_to_supabase(sb, target_table: str, rows: List[Dict[str, Any]], key_columns: List[str], dry_run: bool):
+    if not rows:
+        return {'inserted': 0, 'updated': 0, 'skipped': 0}
+    inserted = 0
+    updated = 0
+    skipped = 0
+    try:
+        if dry_run:
+            return {'inserted': len(rows), 'updated': 0, 'skipped': 0}
+        # attempt bulk upsert (preferred)
+        try:
+            res = sb.table(target_table).upsert(rows).execute()
+            # best-effort: assume rows were inserted/updated
+            inserted = len(rows)
+            return {'inserted': inserted, 'updated': updated, 'skipped': skipped}
+        except AttributeError:
+            # older client: fall back to delete+insert per-row
+            for r in rows:
+                where = {k: r.get(k) for k in key_columns}
+                try:
+                    sb.table(target_table).delete().match(where).execute()
+                except Exception:
+                    pass
+                sb.table(target_table).insert(r).execute()
+                inserted += 1
+            return {'inserted': inserted, 'updated': updated, 'skipped': skipped}
+    except Exception as e:
+        print('Supabase upsert failed:', e)
+        return {'inserted': 0, 'updated': 0, 'skipped': len(rows)}
+
+
+def main(argv: List[str]):
+    p = argparse.ArgumentParser()
+    p.add_argument('--source-dsn', help='Legacy VA-min Postgres DSN (overrides env/settings)')
+    p.add_argument('--source-table', required=True)
+    p.add_argument('--target-table', required=True)
+    p.add_argument('--key-columns', required=True, help='comma-separated list of key columns to dedupe on')
+    p.add_argument('--limit', type=int, default=1000, help='maximum rows to process (0 for all)')
+    p.add_argument('--batch-size', type=int, default=500)
+    p.add_argument('--dry-run', action='store_true')
+    p.add_argument('--store-config', action='store_true', help='store provided DSN into va_settings (encrypted)')
+    args = p.parse_args(argv)
+
+    dsn = get_source_dsn(args.source_dsn)
+    if not dsn:
+        print('ERROR: source DSN not provided. Set VA_MIN_DSN env var or use --source-dsn or store in settings as VA_MIN_DSN')
+        sys.exit(2)
+
+    # option to store DSN encrypted in settings
+    if args.store_config:
+        if args.dry_run:
+            print('dry-run: would store DSN to settings')
+        else:
+            settings_put({'VA_MIN_DSN': dsn})
+            print('stored VA_MIN_DSN into va_settings (encrypted if APP_ENCRYPTION_KEY is set)')
+        return
+
+    # connect to source
+    conn = connect_source(dsn)
+
+    sb = _sbmod._client()
+    if not sb:
+        print('ERROR: Supabase client not configured. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY')
+        sys.exit(2)
+
+    key_cols = [k.strip() for k in args.key_columns.split(',') if k.strip()]
+    processed = 0
+    totals = {'inserted': 0, 'updated': 0, 'skipped': 0}
+
+    offset = 0
+    batch = args.batch_size
+    limit = args.limit
+    while True:
+        if limit and processed >= limit:
+            break
+        to_fetch = batch if (not limit or processed + batch <= limit) else (limit - processed)
+        rows = fetch_batch(conn, args.source_table, to_fetch, offset)
+        if not rows:
+            break
+        # sanitize rows: JSON serializable conversions if needed
+        for r in rows:
+            for k, v in list(r.items()):
+                # psycopg may return bytes for some fields; convert
+                if isinstance(v, (bytes, bytearray)):
+                    try:
+                        r[k] = v.decode('utf-8')
+                    except Exception:
+                        r[k] = None
+        res = upsert_to_supabase(sb, args.target_table, rows, key_cols, args.dry_run)
+        totals['inserted'] += res.get('inserted', 0)
+        totals['updated'] += res.get('updated', 0)
+        totals['skipped'] += res.get('skipped', 0)
+        processed += len(rows)
+        offset += len(rows)
+        print(f"processed {processed} rows (inserted {totals['inserted']})")
+        if limit and processed >= limit:
+            break
+
+    print('done; summary:', totals)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/static/goals.html
+++ b/static/goals.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Goals</title>
+    <style>
+      body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial; margin: 1rem; }
+      table { border-collapse: collapse; width: 100%; max-width: 900px; }
+      th, td { border: 1px solid #ddd; padding: 8px; }
+      th { background: #f6f6f9; text-align: left; }
+      tr:nth-child(even) { background: #fafafa; }
+      .meta { color: #666; font-size: 0.9rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Project Goals</h1>
+    <p class="meta">This is a read-only view of the goals/checklist.</p>
+    <table>
+      <thead>
+        <tr><th>Status</th><th>Goal</th><th>Notes</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Open</td><td>Harden bridge endpoints</td><td>PR #5 merged</td></tr>
+        <tr><td>Open</td><td>CLI wrappers hardening</td><td>PR #6 merged</td></tr>
+        <tr><td>Open</td><td>Docs & importer</td><td>PR #7 merged</td></tr>
+        <tr><td>Open</td><td>FastAPI lifespan migration</td><td>PR #8 merged</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/test_status_goals.py
+++ b/tests/test_status_goals.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from main import app
+
+
+def test_goals_endpoint_serves_html():
+    c = TestClient(app)
+    r = c.get("/status/goals")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")

--- a/tests/test_tools_wrappers.py
+++ b/tests/test_tools_wrappers.py
@@ -1,0 +1,30 @@
+import subprocess
+from tools.github_tools import gh_pr_create
+from tools.railway_tools import _run as rw_run
+
+
+class FakeRun:
+    def __init__(self, rc=0, out="OK", err=""):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = err
+
+
+def test_gh_pr_create_no_shell(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, timeout):
+        # ensure cmd is a list and uses gh pr create
+        assert isinstance(cmd, list)
+        assert "pr" in cmd and "create" in cmd
+        return FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc, out, err = gh_pr_create("main", "feat/x", "t", "b")
+    assert rc == 0
+
+
+def test_railway_run_masks_token(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, timeout):
+        return FakeRun(out=(env.get('RAILWAY_TOKEN','') or 'no'))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc, out, err = rw_run(["railway", "projects", "list"], timeout=5)
+    # out should be string, token masked if present (we didn't set token)
+    assert isinstance(out, str)

--- a/tools/github_tools.py
+++ b/tools/github_tools.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+from typing import Optional, Dict, Any, List
+from vme_lib.supabase_client import settings_get
+
+
+def _gh_env():
+    env = os.environ.copy()
+    tok = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN") or (settings_get("GITHUB_PAT") or "")
+    if tok:
+        env["GH_TOKEN"] = tok
+    return env
+
+
+def _run(cmd: List[str], timeout: int = 60):
+    # NEVER use shell=True; capture output and mask tokens
+    p = subprocess.run(cmd, capture_output=True, text=True, env=_gh_env(), timeout=timeout)
+    out = (p.stdout or "").strip()
+    err = (p.stderr or "").strip()
+    tok = _gh_env().get("GH_TOKEN", "")
+    if tok:
+        out = out.replace(tok, "***")
+        err = err.replace(tok, "***")
+    return p.returncode, out, err
+
+
+def gh_pr_create(base: str, head: str, title: Optional[str] = None, body: Optional[str] = None):
+    # validate branch names minimally
+    for s in (base, head):
+        if not s or any(c.isspace() for c in s):
+            return 400, "", "invalid branch name"
+    cmd = ["gh", "pr", "create", "--base", base, "--head", head, "--fill"]
+    if title:
+        cmd += ["--title", title]
+    if body:
+        cmd += ["--body", body]
+    return _run(cmd)

--- a/tools/railway_tools.py
+++ b/tools/railway_tools.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from typing import Dict, Any, List
+from vme_lib.supabase_client import settings_get
+
+
+def _rw_env():
+    env = os.environ.copy()
+    tok = os.getenv("RAILWAY_TOKEN") or (settings_get("RAILWAY_TOKEN") or "")
+    if tok:
+        env["RAILWAY_TOKEN"] = tok
+    return env
+
+
+def _run(cmd: List[str], timeout: int = 60):
+    p = subprocess.run(cmd, capture_output=True, text=True, env=_rw_env(), timeout=timeout)
+    out = (p.stdout or "").strip()
+    err = (p.stderr or "").strip()
+    tok = _rw_env().get("RAILWAY_TOKEN", "")
+    if tok:
+        out = out.replace(tok, "***")
+        err = err.replace(tok, "***")
+    return p.returncode, out, err
+
+
+def railway_deploy(project_id: str | None = None, service_name: str | None = None):
+    cmd = ["railway", "up"]
+    if project_id:
+        cmd += ["--project", project_id]
+    if service_name:
+        cmd += ["--service", service_name]
+    return _run(cmd, timeout=600)
+
+
+def list_projects_cli() -> Dict[str, Any]:
+    return _run(["railway", "projects", "list"]) if True else (1, "", "disabled")


### PR DESCRIPTION
Summary

Dual-token auth for settings API: server now accepts either a stable CI token (CI_SETTINGS_ADMIN_TOKEN) or the runtime/UI-rotatable token (SETTINGS_ADMIN_TOKEN).

CI updated to use CI_SETTINGS_ADMIN_TOKEN; runtime rotation no longer breaks CI smoke.

Smoke workflow & scripts: smoke.yml, smoke_all.sh (with --save), and railway_preflight.sh.

Railway import stability: package markers + PYTHONPATH=. in Procfile.

Tests + local/deployed smoke verified.

Why

Rotating the admin token via the UI/Supabase previously broke CI. Separating a stable CI token from the runtime/UI token lets operators rotate production safely without touching GitHub secrets.

Changes

main.py: centralized _allowed_admin_tokens(); settings endpoints use it.

.github/workflows/smoke.yml: uses CI_SETTINGS_ADMIN_TOKEN (step env only); uploads smoke_out artifact.

scripts/smoke_all.sh: one-click smoke; auto-start local server; polling tool-events clamp; --save/SMOKE_SAVE_DIR.

scripts/railway_preflight.sh: deployment env sanity checks (+ optional smoke).

Procfile: web: PYTHONPATH=. python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --app-dir .

Added __init__.py package markers; repo imports unified under vme_lib.

Tests: added/updated settings + tool_events clamp tests (all green locally).

Security / Secrets

CI: uses repo/org secret CI_SETTINGS_ADMIN_TOKEN (stable; not rotated by UI).

Runtime: SETTINGS_ADMIN_TOKEN lives in Railway and/or Supabase va_settings and can be rotated from the UI.

Secrets only appear in step-level env (linter-friendly; no forks exposure).

Verification

pytest: 7 passed, 2 warnings.

Local + deployed smoke (Railway):

/health → 200

/api/settings → 200 with new runtime token; 403 with old token

Chat endpoints → 200

Tool-events clamp → validated when session/events present

smoke_out JSON saved locally and uploaded by workflow.

Deploy / Config

GitHub (already done):

Add secret CI_SETTINGS_ADMIN_TOKEN (✅)

Remove secret SETTINGS_ADMIN_TOKEN to avoid confusion (✅)

Railway / Runtime:

Ensure SETTINGS_ADMIN_TOKEN is set (✅)

Optional: store token in Supabase va_settings for UI rotation (✅)

Risk & Rollback

Low risk. Routes gated behind token logic consolidated but behavior is backwards compatible.

Rollback: revert to previous commit; CI still fine since CI token is independent.

Post-merge Runbook

Trigger Actions → “Smoke (deployed)” with base_url=https://<your-app>.railway.app.

(Optional) On Railway shell: scripts/railway_preflight.sh (set RUN_SMOKE=1 to auto-run smoke).

Review smoke_out artifact (pretty JSON traces for quick triage).

Checklist (merge gate)

 CI secret CI_SETTINGS_ADMIN_TOKEN exists in GitHub.

 Runtime SETTINGS_ADMIN_TOKEN set in Railway (and/or Supabase).

 pytest green.

 Manual smoke passes against deployed URL (or acceptable warns for missing optional deps).

 README updated with dual-token policy (✅).

Notes for Agents

CI never depends on the UI token again. Rotate SETTINGS_ADMIN_TOKEN freely via UI; CI keeps working.

Use scripts/smoke_all.sh --save .smoke_out locally; in CI see the smoke_out artifact.
