### PR TITLE
Voice MVP (Whisper): upload endpoint + mic UI + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,9 @@ GITHUB_PAT=<github_pat>
 RAILWAY_TOKEN=<railway_token>
 # BRIDGE_MAX_CALLS is optional
 BRIDGE_MAX_CALLS=20
+
+# Voice MVP
+VOICE_FAKE=1
+WHISPER_MODEL=whisper-1
+# Requires:
+# OPENAI_API_KEY=<your key>    # for real mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          # Fallback to ensure pytest is present even if not listed
-          python - <<'PY'
-          import importlib, subprocess, sys
-          try:
-              importlib.import_module("pytest")
-          except ImportError:
-              subprocess.check_call([sys.executable, "-m", "pip", "install", "pytest"])
-          PY
+          # Ensure runtime deps for audio endpoint and test infrastructure
+          pip install pytest python-multipart aiofiles httpx
 
-      - name: Run tests
+      - name: Run tests (fake voice)
         env:
           PYTHONPATH: .
-        run: pytest -q
+          VOICE_FAKE: "1"
+        run: |
+          PYTHONPATH=. pytest -q
 
   integration:
     runs-on: ubuntu-latest

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -29,3 +29,17 @@ This document describes the runtime requirements for admin tokens, Supabase, and
   - `/api/_debug/supacall` and `/api/_debug/railway_inspect` exist to help diagnose deployment issues (they are intentionally minimal and do not return secret values).
 
 Keep secrets out of git and use your platform secret manager for production deployments.
+
+
+### Voice MVP (Whisper)
+
+This project includes a small Voice MVP that accepts audio uploads and forwards
+them to the OpenAI Whisper transcription API. There are two modes:
+
+- Fake mode: set `VOICE_FAKE=1` to avoid calling external services (used in CI/local tests).
+- Real mode: set `VOICE_FAKE=0` and provide `OPENAI_API_KEY` in the environment.
+
+Notes:
+- File size cap: 15 MB. Supported uploads: `audio/webm` (MediaRecorder), `wav`, `m4a`.
+- The endpoint is `/api/audio/upload`. In fake mode the response includes `"fake": true`.
+- For production, run behind HTTPS and set `VOICE_FAKE=0` and `OPENAI_API_KEY`.

--- a/main.py
+++ b/main.py
@@ -168,6 +168,15 @@ except Exception:
   pass
 
 
+# Ensure audio router (Voice MVP) is mounted (safe include)
+try:
+  from routes.audio import router as audio_router
+  if audio_router:
+    app.include_router(audio_router)
+except Exception:
+  pass
+
+
 # Simple file-backed settings API used by the UI. This keeps settings local to the
 # repository (no external dependency) and allows toggling features such as
 # AGENT_USE_LANGGRAPH from the web UI. Settings are persisted to

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ vosk
 langgraph==0.2.*
 aiofiles
 httpx
+python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ langchain-groq
 whisper
 vosk
 langgraph==0.2.*
+aiofiles
+httpx

--- a/routes/audio.py
+++ b/routes/audio.py
@@ -1,0 +1,101 @@
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from fastapi.responses import JSONResponse
+from typing import Optional
+import os, aiofiles, tempfile, httpx
+
+from graph.va_graph import get_graph
+from lib.supabase_client import safe_log_message, create_session
+
+router = APIRouter(prefix="/api/audio", tags=["audio"])
+
+MAX_BYTES = 15 * 1024 * 1024
+OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
+OPENAI_MODEL = os.getenv("WHISPER_MODEL", "whisper-1")
+
+async def _to_tempfile(upload: UploadFile) -> str:
+    # upload.size may be None depending on the client
+    suffix = "." + (upload.filename.split(".")[-1] if upload.filename and "." in upload.filename else "webm")
+    fd, path = tempfile.mkstemp(prefix="voice_", suffix="."+suffix.strip("."))
+    os.close(fd)
+    size = 0
+    async with aiofiles.open(path, "wb") as out:
+        while True:
+            chunk = await upload.read(65536)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > MAX_BYTES:
+                try:
+                    await out.close()
+                except Exception:
+                    pass
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+                raise HTTPException(413, detail="file too large")
+            await out.write(chunk)
+    return path
+
+
+@router.post("/upload")
+async def upload_audio(
+    file: UploadFile = File(...),
+    session_id: Optional[str] = Form(None),
+    label: Optional[str] = Form(None),
+):
+    # Ensure session
+    if not session_id:
+        sid = create_session(label or "voice")
+        session_id = str(sid) if sid is not None else ""
+
+    # Fake mode (for CI/local)
+    if os.getenv("VOICE_FAKE", "0") == "1" or not os.getenv("OPENAI_API_KEY"):
+        transcript = "FAKE_TRANSCRIPT"
+        try:
+            graph = get_graph()
+            res = graph.invoke({"session_id": session_id, "messages": [{"role": "user", "content": transcript}]})
+            reply = res.get("last_text", "")
+        except Exception:
+            reply = ""
+        try:
+            safe_log_message(session_id, "user", transcript)
+        except Exception:
+            pass
+        try:
+            safe_log_message(session_id, "assistant", reply)
+        except Exception:
+            pass
+        return JSONResponse({"session_id": session_id, "transcript": transcript, "reply": reply, "fake": True})
+
+    # Real Whisper call
+    path = await _to_tempfile(file)
+    try:
+        headers = {"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"}
+        form = {"model": OPENAI_MODEL}
+        files = {"file": (file.filename or "audio.webm", open(path, "rb"), file.content_type or "application/octet-stream")}
+        async with httpx.AsyncClient(timeout=60) as client:
+            r = await client.post(OPENAI_URL, headers=headers, data=form, files=files)
+        if r.status_code >= 400:
+            raise HTTPException(r.status_code, detail=f"OpenAI error: {r.text}")
+        data = r.json()
+        transcript = data.get("text") or data.get("text", "")
+        if not transcript:
+            transcript = str(data)
+        try:
+            graph = get_graph()
+            res = graph.invoke({"session_id": session_id, "messages": [{"role": "user", "content": transcript}]})
+            reply = res.get("last_text", "")
+        except Exception:
+            reply = ""
+        try:
+            safe_log_message(session_id, "user", transcript)
+            safe_log_message(session_id, "assistant", reply)
+        except Exception:
+            pass
+        return {"session_id": session_id, "transcript": transcript, "reply": reply}
+    finally:
+        try:
+            os.remove(path)
+        except Exception:
+            pass

--- a/static/mic.html
+++ b/static/mic.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<title>Voice MVP</title>
+<style>
+  body{font-family:system-ui;margin:24px;max-width:800px}
+  button{padding:.6rem 1rem}
+  .log{white-space:pre-wrap;border:1px solid #eee;background:#fafafa;padding:.75rem;margin-top:1rem}
+</style>
+<h1>Voice MVP</h1>
+<p>Push-to-talk using MediaRecorder. Posts to <code>/api/audio/upload</code>.</p>
+<div>
+  <button id="rec">🎙️ Start</button>
+  <span id="status"></span>
+</div>
+<div class="log" id="log"></div>
+<script>
+(async function(){
+  if(!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia){
+    document.getElementById('status').textContent = 'No mic support in this browser.';
+    return;
+  }
+  const btn = document.getElementById('rec');
+  const log = document.getElementById('log');
+  let rec, chunks = [], recording = false;
+
+  async function sendBlob(blob){
+    const fd = new FormData();
+    fd.append('file', blob, 'audio.webm');
+    const r = await fetch('/api/audio/upload', { method:'POST', body: fd });
+    const j = await r.json();
+    log.textContent += `\n[transcript] ${j.transcript}\n[reply] ${j.reply}\n(session: ${j.session_id})\n`;
+  }
+
+  btn.onclick = async ()=>{
+    if(!recording){
+      const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+      rec = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+      chunks = [];
+      rec.ondataavailable = e => { if (e.data.size) chunks.push(e.data); };
+      rec.onstop = async ()=>{
+        const blob = new Blob(chunks, {type:'audio/webm'});
+        document.getElementById('status').textContent = 'Uploading…';
+        try{ await sendBlob(blob); } catch(e){ log.textContent += `\n[error] ${e}\n`; }
+        document.getElementById('status').textContent = '';
+      };
+      rec.start();
+      recording = true;
+      btn.textContent = '⏹ Stop';
+    } else {
+      rec.stop();
+      recording = false;
+      btn.textContent = '🎙️ Start';
+    }
+  };
+})();
+</script>

--- a/tests/test_audio_upload.py
+++ b/tests/test_audio_upload.py
@@ -1,0 +1,17 @@
+import os
+from io import BytesIO
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_audio_upload_fake(monkeypatch):
+    monkeypatch.setenv("VOICE_FAKE", "1")
+    # Minimal WebM-like bytes (not decoded in fake mode)
+    payload = BytesIO(b"\x1A\x45\xDF\xA3\x00fake")
+    files = {"file": ("fake.webm", payload, "audio/webm")}
+    r = client.post("/api/audio/upload", files=files)
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert j.get("fake") is True
+    assert "transcript" in j and "reply" in j


### PR DESCRIPTION
Adds /api/audio/upload (fake mode for CI), tiny mic UI at /static/mic.html, and tests. No risky runtime changes; OpenAI calls only when VOICE_FAKE=0 and OPENAI_API_KEY set.