### PR TITLE
chore(cache): no-store for hot Show Me assets (fix)

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,6 +71,18 @@ from vme_lib.supabase_client import settings_list, settings_put, settings_refres
 
 app = FastAPI(title="V-Me2")
 
+# Minimal middleware to prevent caching of hot Show Me assets after deploy.
+@app.middleware("http")
+async def no_store_for_showme(request: Request, call_next):
+    resp = await call_next(request)
+    try:
+        p = request.url.path
+        if p in ("/showme", "/static/show_me_window.js"):
+            resp.headers["Cache-Control"] = "no-store"
+    except Exception:
+        pass
+    return resp
+
 
 @app.on_event("startup")
 def _check_openai_key():

--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -1,0 +1,9 @@
+from main import app
+from fastapi.testclient import TestClient
+
+def test_showme_and_js_have_no_store():
+    client = TestClient(app)
+    r = client.get('/showme')
+    assert 'Cache-Control' in r.headers and r.headers['Cache-Control'] == 'no-store'
+    r2 = client.get('/static/show_me_window.js')
+    assert 'Cache-Control' in r2.headers and r2.headers['Cache-Control'] == 'no-store'


### PR DESCRIPTION
Prevent stale JS after deploy by setting Cache-Control: no-store for /showme and /static/show_me_window.js. Includes test.