### PR TITLE
feat(sse): /agent/stream (fake ticks + real fallback)

### DIFF
--- a/static/stream.html
+++ b/static/stream.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>V-Me2 • Stream demo</title>
+    <style>body{font-family:system-ui,Arial;margin:16px;background:#0b0b0c;color:#eef}pre{background:#101214;padding:12px;border-radius:8px}</style>
+  </head>
+  <body>
+    <h2>Stream demo</h2>
+    <p>Connects to <code>/agent/stream?message=hi</code> and appends events.</p>
+    <pre id="out">connecting...
+</pre>
+    <script>
+      const out = document.getElementById('out');
+      out.textContent = '';
+      const params = new URLSearchParams({message: 'hi'});
+      const es = new EventSource('/agent/stream?'+params.toString());
+      es.onmessage = (e) => {
+        try{
+          const d = JSON.parse(e.data);
+          out.textContent += `${d.type}: ${d.text}\n`;
+        }catch(err){
+          out.textContent += e.data + '\n';
+        }
+      }
+      es.onerror = (e) => {
+        out.textContent += '\n[error] connection closed';
+        es.close();
+      }
+    </script>
+  </body>
+</html>

--- a/tests/test_agent_stream.py
+++ b/tests/test_agent_stream.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.mark.parametrize('env_val', ['1', 'true'])
+def test_agent_stream_fake_param(tmp_path, monkeypatch, env_val):
+    # ensure fake-mode
+    monkeypatch.setenv('DEV_LOCAL_LLM', env_val)
+    client = TestClient(app)
+    with client.stream('GET', '/agent/stream?message=hi') as resp:
+        assert resp.status_code == 200
+        body = ''
+        for chunk in resp.iter_text():
+            body += chunk
+        # should contain tick and done event payloads
+        assert '"type": "tick"' in body
+        assert '"type": "done"' in body
+
+
+def test_stream_fake_mode_simple():
+    # Ensure fake/local mode
+    os.environ['DEV_LOCAL_LLM'] = '1'
+    client = TestClient(app)
+    with client.stream("GET", "/agent/stream") as resp:
+        assert resp.status_code == 200
+        data = b""
+        chunks = []
+        for chunk in resp.iter_bytes():
+            data += chunk
+            text = chunk.decode('utf-8', errors='ignore')
+            chunks.append(text)
+            if 'done' in text.lower():
+                break
+        joined = ''.join(chunks)
+        # Expect at least one tick and then a done JSON object
+        assert 'thinking' in joined.lower() or 'tick' in joined.lower()
+    assert 'done' in joined.lower()


### PR DESCRIPTION
- GET /agent/stream SSE endpoint.\n\n- Fake mode when DEV_LOCAL_LLM=1 or no OPENAI_API_KEY: 4 tick events then a done.\n\n- Real mode best-effort: use graph.stream_invoke if available; else single invoke → done.\n\n- Demo page /static/stream.html.\n\n- Test tests/test_agent_stream_fake.py (fast; DEV mode).\n\n- CI runs tests with DEV_LOCAL_LLM=1.\n\n- Smoke hook saves first lines of SSE to artifact.\n\nAcceptance criteria:\n- pytest -q green with DEV_LOCAL_LLM=1.\n- Smoke (START_LOCAL=1 DEV_LOCAL_LLM=1 SMOKE_SAVE_DIR=.smoke_out ./scripts/smoke_all.sh) saves sse_fake_*.txt with ≥4 tick and final done.\n\nRouter safely included in main.py (same try/except pattern).\n\nKeep rate-limit small, reusing existing per-admin limiter if convenient (20 calls/60s default).\n\nYou’re authorized to auto-merge once CI is green.