### PR TITLE
feat(coding): threads API + session title helper

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -43,7 +43,6 @@ Notes:
 - File size cap: 15 MB. Supported uploads: `audio/webm` (MediaRecorder), `wav`, `m4a`.
 - The endpoint is `/api/audio/upload`. In fake mode the response includes `"fake": true`.
 - For production, run behind HTTPS and set `VOICE_FAKE=0` and `OPENAI_API_KEY`.
-<<<<<<< HEAD
 
 
 ### Meeting Mode (real)
@@ -63,5 +62,15 @@ Manual validation: use the Supabase Table Editor to confirm rows are present in 
 
 Notes: this PR implements write-only, best-effort behavior — failures to persist do not change endpoint responses. The Service Role key bypasses RLS; configure policies as desired.
 
-=======
->>>>>>> origin/main
+
+### Threads API (Coding panel)
+
+The Coding panel uses a small Threads API to persist and restore chat-like threads. Endpoints:
+
+- POST `/api/threads` — create a session (body: optional `label`). Returns `{id, title}`.
+- PUT `/api/threads/{id}/title` — update the session label. Returns `{ok,id,title}`.
+- GET `/api/threads?limit=20` — return recent named sessions: `{items:[{id,title,created_at}]}`.
+- GET `/api/threads/{id}/messages` — return ordered messages for a session: `{items:[{id,role,content,created_at}]}`.
+
+These endpoints are best-effort: if Supabase isn't configured the API returns empty lists or `{ok:false}` responses and the UI should handle empty results gracefully.
+

--- a/lib/supabase_client.py
+++ b/lib/supabase_client.py
@@ -55,6 +55,18 @@ def create_session(label: Optional[str] = None) -> Optional[int]:
         return None
 
 
+def update_session_title(session_id: int, title: str) -> bool:
+    """Best-effort: update the label/title of an existing session. Returns True on success."""
+    sb = _client()
+    if not sb:
+        return False
+    try:
+        sb.table("va_sessions").update({"label": title}).eq("id", int(session_id)).execute()
+        return True
+    except Exception:
+        return False
+
+
 def safe_log_message(session_id: Union[int, str, None], role: str, content: str):
     sb = _client()
     if not sb:

--- a/routes/threads.py
+++ b/routes/threads.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Dict, Optional
+import time
+from vme_lib import supabase_client as _sb
+
+router = APIRouter(prefix="/api/threads", tags=["threads"])
+
+
+@router.post("")
+def create_thread(label: Optional[str] = None):
+    """Create a new session/thread. Returns {id, title} where id is a stringified bigint or empty string if unavailable."""
+    try:
+        sid = _sb.create_session(label)
+        return {"id": str(sid) if sid is not None else "", "title": label or ""}
+    except Exception:
+        return {"id": "", "title": label or ""}
+
+
+@router.put("/{id}/title")
+def update_title(id: int, title: str):
+    try:
+        ok = _sb.update_session_title(id, title)
+        return {"ok": bool(ok), "id": str(id), "title": title}
+    except Exception:
+        return {"ok": False, "id": str(id), "title": title}
+
+
+@router.get("")
+def recent_threads(limit: int = Query(20, ge=1, le=200)):
+    """Return recent named threads (label not null/empty) ordered by created_at desc."""
+    sb = _sb._client()
+    if not sb:
+        return {"items": []}
+    try:
+        res = (sb.table("va_sessions")
+               .select("id,label,created_at")
+               .not_("label", "is", None)
+               .neq("label", "")
+               .order("created_at", desc=True)
+               .limit(limit)
+               .execute())
+        rows = res.data or []
+        items = [{"id": str(r.get("id")), "title": r.get("label"), "created_at": r.get("created_at")} for r in rows]
+        return {"items": items}
+    except Exception:
+        return {"items": []}
+
+
+@router.get("/{id}/messages")
+def thread_messages(id: int, limit: int = Query(200, ge=1, le=5000)):
+    sb = _sb._client()
+    if not sb:
+        return {"items": []}
+    try:
+        res = (sb.table("va_messages")
+               .select("id,role,content,created_at")
+               .eq("session_id", int(id))
+               .order("created_at", desc=False)
+               .limit(limit)
+               .execute())
+        rows = res.data or []
+        items = []
+        for r in rows:
+            items.append({
+                "id": r.get("id"),
+                "role": r.get("role"),
+                "content": r.get("content"),
+                "created_at": r.get("created_at"),
+            })
+        return {"items": items}
+    except Exception:
+        return {"items": []}

--- a/scripts/smoke_all.sh
+++ b/scripts/smoke_all.sh
@@ -273,8 +273,6 @@ smoke_voice_fake() {
 if [[ "${VOICE_FAKE:-}" == "1" ]]; then
   smoke_voice_fake
 fi
-<<<<<<< HEAD
-
 # --- meeting smoke (fake) --------------------------------------------------
 smoke_meeting_fake() {
   if [[ "${MEETING_FAKE:-}" != "1" ]]; then
@@ -297,5 +295,39 @@ smoke_meeting_fake() {
 if [[ "${MEETING_FAKE:-}" == "1" ]]; then
   smoke_meeting_fake
 fi
-=======
->>>>>>> origin/main
+
+# --- stream smoke (fake) ----------------------------------------------------
+smoke_stream_fake() {
+  if [[ "${DEV_LOCAL_LLM:-}" != "1" && "${DEV_LOCAL_LLM:-}" != "true" ]]; then
+    echo "[info] DEV_LOCAL_LLM not enabled; skipping stream fake smoke"
+    return 0
+  fi
+  echo "[info] running stream fake smoke..."
+  mkdir -p "$SAVE_DIR" || true
+  curl -sS -H "Accept: text/event-stream" "$BASE_URL/agent/stream?message=hi" -o "$SAVE_DIR/stream.txt" || true
+  echo "[saved] $SAVE_DIR/stream.txt"
+}
+
+# Run stream fake smoke if DEV_LOCAL_LLM=1
+if [[ "${DEV_LOCAL_LLM:-}" == "1" ]]; then
+  smoke_stream_fake
+fi
+ 
+# --- threads smoke ---------------------------------------------------------
+smoke_threads_list() {
+  echo "[info] fetching /api/threads"
+  OUT="$TMPDIR/threads.json"
+  CODE=$(req GET "$BASE_URL/api/threads" "$OUT") || true
+  if [[ "$CODE" == "200" ]]; then
+    ok "Threads list: 200"
+    if [[ -n "$SAVE_DIR" ]]; then
+      cat "$OUT" | save_json threads
+    fi
+  else
+    warn "Threads list: $CODE"
+  fi
+}
+
+# Always attempt threads list (best-effort)
+smoke_threads_list
+ 

--- a/tests/test_chat_logs_user.py
+++ b/tests/test_chat_logs_user.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from main import app
+
+
+def test_agent_chat_logs_user_and_assistant(monkeypatch):
+    calls = []
+
+    def fake_safe_log_message(session_id, role, content):
+        calls.append((session_id, role, content))
+
+    import routes.agent as agent_mod
+    monkeypatch.setattr(agent_mod, "safe_log_message", fake_safe_log_message)
+
+    # Ensure we run the non-fake path so user logging occurs
+    monkeypatch.delenv("DEV_LOCAL_LLM", raising=False)
+
+    class FakeGraph:
+        def invoke(self, state_in, config=None):
+            return {"last_text": "(fake reply)", "tool_events": []}
+
+    monkeypatch.setattr(agent_mod, "get_graph", lambda: FakeGraph())
+    # Ensure a session id is created so user logging runs
+    monkeypatch.setattr(agent_mod, "create_session", lambda label=None: 999)
+
+    client = TestClient(app)
+    r = client.post("/agent/chat", json={"message": "hello world"})
+    assert r.status_code == 200
+    # Expect at least two log calls: user then assistant
+    roles = [c[1] for c in calls]
+    assert "user" in roles
+    assert "assistant" in roles

--- a/tests/test_threads_api_fake.py
+++ b/tests/test_threads_api_fake.py
@@ -1,0 +1,34 @@
+import json
+from fastapi.testclient import TestClient
+import pytest
+
+from main import app
+
+
+def test_threads_endpoints_no_supabase(monkeypatch):
+    # Force no Supabase by monkeypatching the client helper to return None
+    import vme_lib.supabase_client as sc
+    monkeypatch.setattr(sc, "_client", lambda: None)
+    client = TestClient(app)
+
+    # Create thread (should return id key)
+    r = client.post("/api/threads", json={})
+    assert r.status_code == 200
+    j = r.json()
+    assert "id" in j and "title" in j
+
+    # Update title (should return ok key)
+    r2 = client.put("/api/threads/123/title", params={"title": "X"})
+    assert r2.status_code == 200
+    j2 = r2.json()
+    assert j2.get("ok") in (True, False)
+
+    # Recent list
+    r3 = client.get("/api/threads")
+    assert r3.status_code == 200
+    assert isinstance(r3.json().get("items"), list)
+
+    # Messages
+    r4 = client.get("/api/threads/123/messages")
+    assert r4.status_code == 200
+    assert isinstance(r4.json().get("items"), list)


### PR DESCRIPTION
C1: Threads API endpoints for Coding panel.\n\n- POST /api/threads -> create session (returns {id,title}).\n- PUT /api/threads/{id}/title -> update label.\n- GET /api/threads -> recent named threads.\n- GET /api/threads/{id}/messages -> messages for thread.\n\nAll endpoints are best-effort when Supabase is not configured. Includes tests and smoke step.