### PR TITLE
feat(coding): UI shell (sidebar + chat pane + composer)

### DIFF
--- a/static/coding.css
+++ b/static/coding.css
@@ -1,0 +1,20 @@
+:root{--sidebar-width:280px;--bg:#0f1724;--panel:#0b1220;--muted:#94a3b8;--accent:#0ea5a4}
+*{box-sizing:border-box;font-family:system-ui,-apple-system,Segoe UI,Roboto,'Helvetica Neue',Arial}
+body{margin:0;background:var(--bg);color:#e6eef8}
+#coding-app{display:grid;grid-template-columns:var(--sidebar-width) 1fr;height:100vh}
+.sidebar{background:#071224;padding:12px;border-right:1px solid rgba(255,255,255,0.03);overflow:auto}
+.sidebar-actions{display:flex;flex-direction:column;gap:8px;margin-bottom:12px}
+.sidebar-actions button{padding:8px 10px;border-radius:8px;border:1px solid rgba(255,255,255,0.04);background:#031623;color:#dff}
+.recent-list{display:flex;flex-direction:column;gap:6px}
+.recent-item{padding:8px;border-radius:6px;background:rgba(255,255,255,0.02);cursor:pointer}
+.recent-item:hover{background:rgba(255,255,255,0.03)}
+.main{display:flex;flex-direction:column;height:100%}
+.history{flex:1;overflow:auto;padding:16px;display:flex;flex-direction:column;gap:12px}
+.composer{padding:10px;border-top:1px solid rgba(255,255,255,0.03);display:flex;gap:10px;align-items:flex-end}
+#composer-input{flex:1;min-height:44px;max-height:160px;border-radius:8px;padding:8px;border:1px solid rgba(255,255,255,0.04);background:#071827;color:#eaf6ff}
+.controls{display:flex;gap:8px}
+.controls button{padding:8px 10px;border-radius:8px;border:1px solid rgba(255,255,255,0.04);background:#041a1a;color:#dff}
+.bubble{max-width:70%;padding:10px;border-radius:10px;box-shadow:0 1px 0 rgba(0,0,0,0.3)}
+.bubble.user{align-self:flex-end;background:linear-gradient(180deg,#06b6d4,#0891b2);color:#022}
+.bubble.assistant{align-self:flex-start;background:#051122;color:#eaf6ff}
+.muted{color:var(--muted);font-size:13px}

--- a/static/coding.html
+++ b/static/coding.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Coding (beta)</title>
+  <link rel="stylesheet" href="/static/coding.css?v=" + Date.now()>
+</head>
+<body>
+  <div id="coding-app">
+    <div class="sidebar" id="coding-sidebar">
+      <div class="sidebar-actions">
+        <button id="btnNew">New chat</button>
+        <button id="btnSaveName">Save & name</button>
+      </div>
+      <div class="recent-list" id="recentList"></div>
+    </div>
+
+    <div class="main" id="coding-main">
+      <div class="history" id="history"></div>
+      <div class="composer" id="composer">
+        <textarea id="composer-input" placeholder="Type a message..."></textarea>
+        <div class="controls">
+          <button id="btnMic">🎙️</button>
+          <button id="btnAttach">+</button>
+          <button id="btnSend">Send</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    // Simple cache-busting loader for the JS
+    var s = document.createElement('script'); s.src = '/static/coding.js?v=' + Date.now(); s.defer = true; document.head.appendChild(s);
+  </script>
+</body>
+</html>

--- a/static/coding.js
+++ b/static/coding.js
@@ -1,0 +1,85 @@
+(() => {
+  const $ = (sel) => document.querySelector(sel);
+  let currentSessionId = "";
+  let messages = [];
+
+  function renderRecent(items){
+    const el = $('#recentList'); el.innerHTML = '';
+    (items||[]).forEach(it => {
+      const d = document.createElement('div'); d.className = 'recent-item'; d.textContent = it.title || ('id:'+it.id);
+      d.onclick = async () => { currentSessionId = String(it.id); await loadThread(it.id); render(); };
+      el.appendChild(d);
+    });
+  }
+
+  async function fetchRecent(){
+    try{
+      const r = await fetch('/api/threads?limit=20'); if(!r.ok) throw r;
+      const j = await r.json(); return j.items || [];
+    }catch(e){ return []; }
+  }
+
+  async function loadThread(id){
+    try{
+      const r = await fetch(`/api/threads/${id}/messages`); if(!r.ok) throw r;
+      const j = await r.json(); messages = j.items || [];
+    }catch(e){ messages = []; }
+  }
+
+  function render(){
+    const hist = $('#history'); hist.innerHTML = '';
+    messages.forEach(m => {
+      const b = document.createElement('div'); b.className = 'bubble ' + (m.role==='user' ? 'user':'assistant'); b.textContent = m.content || m.text || '';
+      hist.appendChild(b);
+    });
+    $('#composer-input').value = '';
+  }
+
+  async function refreshRecent(){
+    const items = await fetchRecent(); renderRecent(items);
+  }
+
+  async function sendMessage(){
+    const ta = $('#composer-input'); const txt = ta.value.trim(); if(!txt) return;
+    // push user bubble immediately
+    messages.push({role:'user', content: txt}); render();
+    // call server
+    const payload = {message: txt}; if(currentSessionId) payload.session_id = currentSessionId;
+    try{
+      const r = await fetch('/agent/chat', {method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload)});
+      if(!r.ok){ throw r; }
+      const j = await r.json();
+      // append assistant
+      messages.push({role:'assistant', content: j.text || j.message || ''});
+      if(j.session_id) currentSessionId = String(j.session_id);
+      render();
+      await refreshRecent();
+    }catch(e){ messages.push({role:'assistant', content: '(error)'}); render(); }
+  }
+
+  function init(){
+    $('#btnNew').onclick = () => { currentSessionId=''; messages = []; render(); };
+    $('#btnSaveName').onclick = async () => {
+      const title = prompt('Enter a title for this thread') || '';
+      if(!title) return;
+      try{
+        if(!currentSessionId){
+          const r = await fetch('/api/threads', {method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({label: title})});
+          const j = await r.json(); currentSessionId = String(j.id || j.session || j.id || '');
+        } else {
+          await fetch(`/api/threads/${currentSessionId}/title?title=${encodeURIComponent(title)}`, {method:'PUT'});
+        }
+      }catch(e){}
+      await refreshRecent();
+    };
+    $('#btnSend').onclick = () => { sendMessage(); };
+    $('#btnAttach').onclick = () => { alert('Document upload is not yet enabled'); };
+    // Mic placeholder toggle
+    let micOn = false; $('#btnMic').onclick = () => { micOn = !micOn; $('#btnMic').textContent = micOn ? '🎙️•' : '🎙️'; };
+
+    refreshRecent(); render();
+  }
+
+  window.initCodingPanel = init;
+  document.addEventListener('DOMContentLoaded', ()=>{ try{ init(); }catch(e){} });
+})();

--- a/tests/test_coding_page_serves.py
+++ b/tests/test_coding_page_serves.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+def test_coding_page_serves():
+    client = TestClient(app)
+    r = client.get('/static/coding.html')
+    assert r.status_code == 200
+    body = r.text
+    assert 'id="coding-app"' in body
+    assert 'Save & name' in body

--- a/tests/test_threads_api_shapes.py
+++ b/tests/test_threads_api_shapes.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+def test_threads_shapes():
+    client = TestClient(app)
+    r = client.get('/api/threads?limit=5')
+    assert r.status_code == 200
+    j = r.json()
+    assert 'items' in j and isinstance(j['items'], list)
+
+    r2 = client.get('/api/threads/123/messages')
+    assert r2.status_code == 200
+    j2 = r2.json()
+    assert 'items' in j2 and isinstance(j2['items'], list)


### PR DESCRIPTION
Adds a lightweight Coding panel UI shell: left sidebar with Recent threads, main chat history, and composer (Send, Mic placeholder, + attachment placeholder).\n\nAcceptance:\n- /static/coding.html loads with id="coding-app"\n- Recent shows named threads (empty ok)\n- New chat clears state\n- Save & name calls Threads API and refreshes Recent\n- Send posts to /agent/chat (non-streaming) and renders bubbles\n- Mic toggles placeholder dictation icon and fills input when supported\n