### PR TITLE
ci(scripts): tokenized ops stream smoke + docs

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -61,4 +61,6 @@ Then open an EventSource to the stream endpoint using the token:
 
 Set `OPS_STREAM_SECRET` in your environment to a secret used to HMAC-sign tokens. If unset, `SETTINGS_ADMIN_TOKEN` will be used as fallback (not recommended for production).
 
+Note: tokens expire after 5 minutes. In production set `OPS_STREAM_SECRET` to a strong random value.
+
 Persisted schema: va_tasks(id, created_at, title, status); va_task_events(id, created_at, task_id, kind, data_json).

--- a/config/goals.json
+++ b/config/goals.json
@@ -115,7 +115,7 @@
     "how": "In-app task queue + SSE event log; admin-gated API to create/cancel tasks; in-proc fake mode and Supabase persistence when available; UI hook in Coding panel",
     "tools": "SETTINGS_ADMIN_TOKEN, DEV_LOCAL_LLM, SUPABASE_*, optional OPENAI_API_KEY",
     "status": "LIVE",
-    "notes": "Admin-gated API + SSE in Coding panel; fake-mode deterministic stream; best-effort Supabase persistence."
+    "notes": "Admin-gated API + SSE in Coding panel; fake-mode deterministic stream; best-effort Supabase persistence. SSE auth hardening (ephemeral tokens) implemented."
   },
   {
     "goal": "Railway GraphQL projects resolver",

--- a/tests/test_coding_js_has_attach_handler.py
+++ b/tests/test_coding_js_has_attach_handler.py
@@ -1,0 +1,6 @@
+def test_coding_js_has_attach_handler():
+    from pathlib import Path
+    p = Path(__file__).resolve().parent.parent / 'static' / 'coding.js'
+    s = p.read_text(encoding='utf-8')
+    assert 'attach-btn' in s
+    assert "Document upload is not yet enabled" in s

--- a/tests/test_coding_page_has_attach_button.py
+++ b/tests/test_coding_page_has_attach_button.py
@@ -1,0 +1,5 @@
+def test_coding_html_has_attach_button():
+    from pathlib import Path
+    p = Path(__file__).resolve().parent.parent / 'static' / 'coding.html'
+    s = p.read_text(encoding='utf-8')
+    assert 'id="attach-btn"' in s


### PR DESCRIPTION
Add tokenized ops stream path to smoke_all.sh (uses /ops/stream_tokens when available). Update goals and OPERATIONS.md notes.